### PR TITLE
[#57] Restrict Deploy of APK only when push to master.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,4 +46,4 @@ script:
     - cocos compile -p android -j 8
 
 after_success:
-    - curl -F "file=@./bin/debug/android/KonaReflection-debug.apk" -F "token=${DEPLOYGATE_TOKEN}" -F "message=Deploy from Travis CI" https://deploygate.com/api/users/pankona/apps
+    - '[ "$TRAVIS_BRANCH" == "master" ] && curl -F "file=@./bin/debug/android/KonaReflection-debug.apk" -F "token=${DEPLOYGATE_TOKEN}" -F "message=Deploy from Travis CI" https://deploygate.com/api/users/pankona/apps'

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,4 +46,6 @@ script:
     - cocos compile -p android -j 8
 
 after_success:
-    - '[ "$TRAVIS_BRANCH" == "master" ] && curl -F "file=@./bin/debug/android/KonaReflection-debug.apk" -F "token=${DEPLOYGATE_TOKEN}" -F "message=Deploy from Travis CI" https://deploygate.com/api/users/pankona/apps'
+    - echo $TRAVIS_BRANCH
+    - echo $TRAVIS_PULL_REQUEST
+    - '[ "$TRAVIS_BRANCH" == "master" -a "$TRAVIS_PULL_REQUEST" == "false" ] && curl -F "file=@./bin/debug/android/KonaReflection-debug.apk" -F "token=${DEPLOYGATE_TOKEN}" -F "message=Deploy from Travis CI" https://deploygate.com/api/users/pankona/apps'


### PR DESCRIPTION
PR for #57.
Restrict the time to deploy apk to DeployGate only when push invoked to "master".
