### PR TITLE
[#75] Upper draw doesn't stack dept to vetical draw

### DIFF
--- a/src/Classes/GameScene/ModelManager.cpp
+++ b/src/Classes/GameScene/ModelManager.cpp
@@ -375,6 +375,12 @@ ModelManager::startVerticalDraw(int in_y) {
 void
 ModelManager::updateVerticalDraw(int in_y) {
    verticalDrawEnd.y = in_y;
+
+   // if draw towards upper, update start position
+   // not to stack debt to vetical draw.
+   if (verticalDrawEnd.y > verticalDrawStart.y) {
+       verticalDrawStart.y = verticalDrawEnd.y;
+   }
 }
 
 void


### PR DESCRIPTION
## Pull Request for #75
## Updates
- Upper draw doesn't stack debt to vertical draw.
### Status of Pull Request
- [x] Implement
- [x] Review
- [x] Reflect review result
