### PR TITLE
[#110] ball position moves depends on bar position at game ready

### DIFF
--- a/src/Classes/GameScene/GameControl.cpp
+++ b/src/Classes/GameScene/GameControl.cpp
@@ -22,6 +22,10 @@ GameControl::update(float delta) {
 
     mm.progress(delta);
 
+    if (gameState == GameState::READY) {
+        mm.setBallPositionX(mm.getBarPosition().x);
+    }
+
     // these should be treated on callback from model manager.
     vm.setBarPosition(mm.getBarPosition());
     vm.setBallPosition(mm.getBallPosition());
@@ -112,14 +116,14 @@ GameControl::onViewManagerEvent(ViewManagerEvent in_event, void* arg) {
 
                 // let mm remember y position
                 mm.startVerticalDraw(p->y);
-                mm.setBallAndBarPositionX(p->x);
+                mm.setBarPositionX(p->x);
                 break;
             case ViewManagerEvent::TOUCH_MOVED:
                 p = (Position*) arg;
 
                 // let mm update y position
                 mm.updateVerticalDraw(p->y);
-                mm.setBallAndBarPositionX(p->x);
+                mm.setBarPositionX(p->x);
                 break;
             case ViewManagerEvent::TOUCH_ENDED:
                 // let mm decide y position

--- a/src/Classes/GameScene/ModelManager.cpp
+++ b/src/Classes/GameScene/ModelManager.cpp
@@ -654,7 +654,7 @@ ModelManager::addModelManagerEventListener(ModelManagerEventListener* in_listene
 }
 
 void
-ModelManager::setBallAndBarPositionX(int in_x) {
+ModelManager::setBarPositionX(int in_x) {
     lastTouchedPosition.x = in_x;
 
     if (isTouchOnRightSideOfBar(in_x)) {
@@ -662,9 +662,12 @@ ModelManager::setBallAndBarPositionX(int in_x) {
     } else {
         bar->setDirection(BarDirection::LEFT);
     }
+}
 
+void
+ModelManager::setBallPositionX(int in_x) {
     Position p;
-    p.x = bar->getPosition().x;
+    p.x = in_x;
     p.y = ball->getPosition().y;
     ball->setPosition(p);
 }

--- a/src/Classes/GameScene/ModelManager.h
+++ b/src/Classes/GameScene/ModelManager.h
@@ -63,7 +63,8 @@ public:
     void setBallSpeed(int);
     void resetBall();
 
-    void setBallAndBarPositionX(int);
+    void setBarPositionX(int);
+    void setBallPositionX(int);
 
     void setFieldSize(int, int);
 


### PR DESCRIPTION
## Pull Request for issue #110
## Updates
- ball position moves depends on bar position at game ready
### Status of Pull Request
- [x] Implement
- [x] Behavior validation on PC
- [x] Review
- [x] Reflect review result
