### PR TITLE
[#114] correction of collision detection between ball and bar

### DIFF
--- a/src/Classes/GameScene/Bar.cpp
+++ b/src/Classes/GameScene/Bar.cpp
@@ -1,4 +1,5 @@
 #include "Bar.h"
+#include <iostream>
 
 // public methods
 
@@ -105,5 +106,26 @@ Bar::startSwinging() {
 void
 Bar::endSwinging() {
     is_swinging = false;
+}
+
+Kona::Vector2D
+Bar::getVector2DOfBarSide(SIDE in_barSide) {
+    // ToDo: implement
+    return Kona::Vector2D();
+}
+
+Kona::Vector2D
+Bar::getVector2DOfBar() {
+    Kona::Point startPosition;
+    Kona::Point TerminalPosition;
+
+    if (currentPivot == LEFT) {
+        startPosition = Kona::Point(position.x - width / 2, position.y);
+        return Kona::Vector2D(Kona::Vector(width, angle), startPosition);
+    } else if (currentPivot == RIGHT) {
+    } else {
+    }
+    std::cout << "[" << __func__ << "][" << __LINE__ << "] should not reach here!" << std::endl;
+    return Kona::Vector2D();
 }
 

--- a/src/Classes/GameScene/Bar.cpp
+++ b/src/Classes/GameScene/Bar.cpp
@@ -9,6 +9,8 @@ Bar::Bar() {
     height = 10;
     direction = BarDirection::NONE;
     speed = 10;
+    angle = 0;
+    currentPivot = LEFT;
 }
 
 void
@@ -67,3 +69,25 @@ BarDirection
 Bar::getDirection() {
     return (BarDirection) direction;
 }
+
+
+void
+Bar::setAngle(int in_angle) {
+    angle = in_angle;
+}
+
+int
+Bar::getAngle() {
+    return angle;
+}
+
+void
+Bar::setPivot(Pivot in_pivot) {
+    currentPivot = in_pivot;
+}
+
+Bar::Pivot
+Bar::getPivot() {
+    return currentPivot;
+}
+

--- a/src/Classes/GameScene/Bar.cpp
+++ b/src/Classes/GameScene/Bar.cpp
@@ -11,6 +11,7 @@ Bar::Bar() {
     speed = 10;
     angle = 0;
     currentPivot = LEFT;
+    is_swinging = false;
 }
 
 void
@@ -89,5 +90,20 @@ Bar::setPivot(Pivot in_pivot) {
 Bar::Pivot
 Bar::getPivot() {
     return currentPivot;
+}
+
+bool
+Bar::isSwinging() {
+    return is_swinging;
+}
+
+void
+Bar::startSwinging() {
+    is_swinging = true;
+}
+
+void
+Bar::endSwinging() {
+    is_swinging = false;
 }
 

--- a/src/Classes/GameScene/Bar.h
+++ b/src/Classes/GameScene/Bar.h
@@ -19,6 +19,7 @@ private:
         CENTER
     };
     Pivot currentPivot;
+    bool is_swinging;
 
 public:
     Bar();
@@ -37,6 +38,9 @@ public:
     int getAngle();
     void setPivot(Pivot);
     Pivot getPivot();
+    bool isSwinging();
+    void startSwinging();
+    void endSwinging();
 };
 
 #endif // __BAR_H__

--- a/src/Classes/GameScene/Bar.h
+++ b/src/Classes/GameScene/Bar.h
@@ -12,6 +12,13 @@ private:
     int height;
     int direction;
     int speed;
+    int angle;
+    enum Pivot {
+        LEFT,
+        RIGHT,
+        CENTER
+    };
+    Pivot currentPivot;
 
 public:
     Bar();
@@ -26,6 +33,10 @@ public:
     int getSpeed();
     void setDirection(BarDirection);
     BarDirection getDirection();
+    void setAngle(int);
+    int getAngle();
+    void setPivot(Pivot);
+    Pivot getPivot();
 };
 
 #endif // __BAR_H__

--- a/src/Classes/GameScene/Bar.h
+++ b/src/Classes/GameScene/Bar.h
@@ -3,6 +3,7 @@
 
 #include "Position.h"
 #include "BarDirection.h"
+#include <KonaVector2D.h>
 
 class Bar {
 
@@ -41,6 +42,19 @@ public:
     bool isSwinging();
     void startSwinging();
     void endSwinging();
+    enum SIDE {
+        UPPER,
+        DOWNER,
+        RIGHTER,
+        LEFTER,
+        CORNER_RIGHTER_DOWNER,
+        CORNER_RIGHTER_UPPER,
+        CORNER_LEFTER_DOWNER,
+        CORNER_LEFTER_UPPER,
+        UNKNOWN
+    };
+    Kona::Vector2D getVector2DOfBarSide(SIDE);
+    Kona::Vector2D getVector2DOfBar();
 };
 
 #endif // __BAR_H__

--- a/src/Classes/GameScene/ModelManager.cpp
+++ b/src/Classes/GameScene/ModelManager.cpp
@@ -587,19 +587,6 @@ calculateCrossOfBallAndBar(Ball& in_ball, Bar &in_bar, int in_currentBarAngle) {
     return bar_v.cross (ball_v) / bar_v.getLength();
 }
 
-static bool
-doBallCollideOnSideOfBar (Ball& in_ball, Bar& in_bar, int in_currentBarAngle) {
-
-    Kona::Vector ball_v(Kona::Point(in_ball.getPosition().x - (in_bar.getPosition().x - in_bar.getWidth() / 2),
-                                    in_ball.getPosition().y - in_bar.getPosition().y));
-    Kona::Vector bar_v(in_bar.getWidth(), in_currentBarAngle);
-    int cosx = ball_v.dot (bar_v) / bar_v.getLength();
-    if (cosx < 0 || cosx > bar_v.getLength()) {
-        return true;
-    }
-    return false;
-}
-
 static float
 calcReflectAngleByCollideBar(Ball in_ball, Bar in_bar, float in_currentBarAngle) {
     int unitLength = 1;
@@ -637,30 +624,25 @@ ModelManager::calculateBallReflection(int in_currentBarAngle, Ball& inout_ball) 
         return;
     }
 
-    if (doBallCollideOnSideOfBar(inout_ball, *bar, in_currentBarAngle)) {
-        BALL_REFLECT_X();
-    } else {
 #ifndef TEST
-        Kona::Point intersectPoint;
-        Kona::Vector2D barVector2d = bar->getVector2DOfBar();
-        Kona::Vector2D stretchedVector2D = strechBarVector(&barVector2d, inout_ball.getRadius());
-        inout_ball.getVector2D().calcIntersectPoint(stretchedVector2D, &intersectPoint);
-        Kona::Vector2D distanceVector(inout_ball.getVector2D().getStartPosition(), intersectPoint);
-        float newAngle = calcReflectAngleByCollideBar(*ball, *bar, in_currentBarAngle);
-        float newSpeed = inout_ball.getSpeed() - distanceVector.getLength();
-        inout_ball.setPosition(intersectPoint.x, intersectPoint.y);
-        inout_ball.setSpeed(newSpeed);
-        inout_ball.setDirection(newAngle);
-        float ballCross = calculateCrossOfBallAndBar (*ball, *bar, in_currentBarAngle);
-        ball->addVector(Kona::Vector(-1 * ballCross * 2, in_currentBarAngle + 90));
-        sleep(1);
+    Kona::Point intersectPoint;
+    Kona::Vector2D barVector2d = bar->getVector2DOfBar();
+    Kona::Vector2D stretchedVector2D = strechBarVector(&barVector2d, inout_ball.getRadius());
+    inout_ball.getVector2D().calcIntersectPoint(stretchedVector2D, &intersectPoint);
+    Kona::Vector2D distanceVector(inout_ball.getVector2D().getStartPosition(), intersectPoint);
+    float newAngle = calcReflectAngleByCollideBar(*ball, *bar, in_currentBarAngle);
+    float newSpeed = inout_ball.getSpeed() - distanceVector.getLength();
+    inout_ball.setPosition(intersectPoint.x, intersectPoint.y);
+    inout_ball.setSpeed(newSpeed);
+    inout_ball.setDirection(newAngle);
+    float ballCross = calculateCrossOfBallAndBar (*ball, *bar, in_currentBarAngle);
+    ball->addVector(Kona::Vector(-1 * ballCross * 2, in_currentBarAngle + 90));
 #else /* for testing */ 
-        //ball->addVector(Kona::Vector(-1 * ballCross * 2, 90));
-        ball->setSpeed(10);
-        ball->setDirection(45);
-        inout_ball.setPosition(field->getWidth() / 2, ball->getPosition().y);
+    //ball->addVector(Kona::Vector(-1 * ballCross * 2, 90));
+    ball->setSpeed(10);
+    ball->setDirection(45);
+    inout_ball.setPosition(field->getWidth() / 2, ball->getPosition().y);
 #endif
-    }
 }
 
 // public method

--- a/src/Classes/GameScene/ModelManager.cpp
+++ b/src/Classes/GameScene/ModelManager.cpp
@@ -258,8 +258,6 @@ ModelManager::moveBall(float delta) {
     int height = field->getHeight();
     int radius = ball->getRadius();
 
-    static int reflectCount = 0;
-
     // temp ball initialization
     Ball tempBall;
     tempBall.setPosition(ball->getPosition().x, ball->getPosition().y);
@@ -612,7 +610,6 @@ strechBarVector(Kona::Vector2D* inout_barVector2d, int in_length) {
 void
 ModelManager::calculateBallReflection(int in_currentBarAngle, Ball& inout_ball) {
 
-    static int reflectCount = 0;
     if (ball->getSpeed() == 0) {
         int hitSpeed = 10;
 #ifndef TEST

--- a/src/Classes/GameScene/ModelManager.cpp
+++ b/src/Classes/GameScene/ModelManager.cpp
@@ -43,7 +43,7 @@ ModelManager::isTouchOnRightSideOfBar(int in_x) {
 void
 ModelManager::moveBar(float delta) {
 
-    if (isBarSwinging) {
+    if (bar->isSwinging()) {
         progressBarSwinging();
     }
 
@@ -415,7 +415,7 @@ ModelManager::moveBall(float delta) {
         }
 
         if (doCollideBallAndBar(tempBall) ||
-            hasCollisionWhileBarSwinging(*bar, tempBall, isBarSwinging)) {
+            hasCollisionWhileBarSwinging(*bar, tempBall, bar->isSwinging())) {
             onCollisionBallAndBar(tempBall);
         }
 
@@ -498,7 +498,7 @@ ModelManager::shouldSwingBar(int in_angle) {
 
 void
 ModelManager::startSwinging() {
-    isBarSwinging = true;
+    bar->startSwinging();
     barSwingElapsedFrame = 0;
     currentSwingState = 0;
     barFollowthroughElapsedFrame = 0;
@@ -507,7 +507,7 @@ ModelManager::startSwinging() {
 
 void
 ModelManager::endSwinging() {
-    isBarSwinging = false;
+    bar->endSwinging();
     isAlreadyHitBySwing = false;
     barSwingElapsedFrame = 0;
     currentSwingState = 0;
@@ -657,7 +657,6 @@ ModelManager::initialize() {
     int initialLife = 3;
     player = new Player(initialLife);
 
-    isBarSwinging = false;
     currentSwingState = 0;
     isAlreadyHitBySwing = false;
 }
@@ -702,7 +701,7 @@ ModelManager::onCollisionBallAndBar(Ball& in_ball) {
     Position ballPosition = in_ball.getPosition();
     Position barPosition = bar->getPosition();
 
-    if (isBarSwinging) {
+    if (bar->isSwinging()) {
         if (isAlreadyHitBySwing) {
             return;
         }
@@ -716,7 +715,7 @@ ModelManager::onCollisionBallAndBar(Ball& in_ball) {
         return;
     }
 
-    int currentBarAngle = getVerticalDrawDelta();
+    int currentBarAngle = bar->getAngle();
     calculateBallReflection(currentBarAngle, in_ball);
 }
 
@@ -838,7 +837,7 @@ ModelManager::getBlockPosition(int index) {
 bool
 ModelManager::doCollideBallAndBar(Ball in_ball) {
 
-    int currentBarAngle = getVerticalDrawDelta();
+    int currentBarAngle = bar->getAngle();
     float ballCross = calculateCrossOfBallAndBar (in_ball, *bar, currentBarAngle);
     if (ballCross > 0) {
         return false;
@@ -909,17 +908,18 @@ ModelManager::isPlayerStillAlive() {
 
 void
 ModelManager::startVerticalDraw(int in_y) {
-    if (isBarSwinging) {
+    if (bar->isSwinging()) {
         return;
     }
 
     verticalDrawStart.y = in_y;
     verticalDrawEnd.y = in_y;
+    bar->setAngle(getVerticalDrawDelta());
 }
 
 void
 ModelManager::updateVerticalDraw(int in_y) {
-    if (isBarSwinging) {
+    if (bar->isSwinging()) {
         return;
     }
 
@@ -930,6 +930,7 @@ ModelManager::updateVerticalDraw(int in_y) {
     if (verticalDrawEnd.y > verticalDrawStart.y) {
         verticalDrawStart.y = verticalDrawEnd.y;
     }
+    bar->setAngle(getVerticalDrawDelta());
 }
 
 static int
@@ -939,7 +940,7 @@ calculateVerticalDrawDelta(int start, int end) {
 
 void
 ModelManager::endVerticalDraw() {
-    if (isBarSwinging) {
+    if (bar->isSwinging()) {
         return;
     }
 
@@ -950,6 +951,7 @@ ModelManager::endVerticalDraw() {
 
     verticalDrawStart.y = 0;
     verticalDrawEnd.y = 0;
+    bar->setAngle(getVerticalDrawDelta());
 }
 
 int
@@ -967,5 +969,5 @@ ModelManager::getVerticalDrawDelta() {
 
 bool
 ModelManager::barSwinging() {
-    return isBarSwinging;
+    return bar->isSwinging();
 }

--- a/src/Classes/GameScene/ModelManager.h
+++ b/src/Classes/GameScene/ModelManager.h
@@ -21,7 +21,6 @@ private:
     std::vector<ModelManagerEventListener*> listeners;
     Position verticalDrawStart;
     Position verticalDrawEnd;
-    bool isBarSwinging;
     int barSwingElapsedFrame;
     int barFollowthroughElapsedFrame;
     int currentSwingState;


### PR DESCRIPTION
## Pull Request for issue #114
## Updates
- correct logic to calculate reflection when collision occurs between ball and bar
- add logic to calculate reflection when ball collides to bar from bar's back.
- change logic ball hits to side of bar.
### Status of Pull Request
- [x] Implement
- [x] Behavior validation on PC
- [x] Review
- [x] Reflect review result
